### PR TITLE
Removed ArcGIS API key

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,7 @@
       function(esriConfig, Map, FeatureLayer, MapView, Legend, UniqueValueRenderer) {
         
 
-        esriConfig.apiKey = "AAPK3850a9ec91324a028768557dfc40d4ffvcIaUta3f0VFXfQzaX-fRYTub_0wRicii4v_tCY7CXnPSWbfsb44_DLmQKj3rJHv";
+        esriConfig.apiKey = "";
 
 //        Example from Arcgis site: https://developers.arcgis.com/javascript/latest/display-a-map/#reference-the-api
 


### PR DESCRIPTION
Removed a vulnerable API key in the ``index.html`` file that interacts with the ArcGIS Maps SDK. Since old commits are visible, may need to create a new API key just to be on the safe side. I seen commits for adding the ``.env`` file to the ``.gitignore``, definitely a better place for that key 😄 